### PR TITLE
Implement enemy removal when hit

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -103,14 +103,22 @@ class Game extends Phaser.Scene {
         // Atualizar a direção de cada projétil em direção ao alvo
         this.projectiles.children.each(projectile => {
             if (!projectile.active || !projectile.target) return;
+            if (!projectile.target.active) {
+                projectile.destroy();
+                return;
+            }
             const angle = Phaser.Math.Angle.Between(projectile.x, projectile.y, projectile.target.x, projectile.target.y);
             projectile.body.setVelocity(
                 Math.cos(angle) * this.projectileSpeed,
                 Math.sin(angle) * this.projectileSpeed
             );
 
-            // destruir projétil se estiver muito próximo do alvo
+            // destruir projétil e inimigo se estiver muito próximo do alvo
             if (Phaser.Math.Distance.Between(projectile.x, projectile.y, projectile.target.x, projectile.target.y) < 10) {
+                // remove inimigo da tela
+                projectile.target.destroy();
+                // remove inimigo do array de inimigos
+                this.enemies = this.enemies.filter(e => e !== projectile.target);
                 projectile.destroy();
             }
 


### PR DESCRIPTION
## Summary
- remove enemies when projectiles get close to them
- destroy projectiles whose targets are gone

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a06866d78832c81cc61e2cabc6a36