### PR TITLE
Add game HUD with live stats

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -10,6 +10,7 @@ import {
     separateEnemies
 } from "./helpers/enemies";
 import { fireProjectile, updateProjectiles } from "./helpers/projectiles";
+import { HUD_TEXTS } from "./HUDConstants";
 
 class Game extends Phaser.Scene {
     constructor() {
@@ -24,6 +25,10 @@ class Game extends Phaser.Scene {
         this.wasdKeys = null;
         this.projectiles = null;
         this.projectileSpeed = 300;
+
+        this.hudTexts = {};
+        this.enemiesTotal = 0;
+        this.startTime = 0;
     }
 
     create() {
@@ -45,7 +50,18 @@ class Game extends Phaser.Scene {
         });
 
         // Criar vários inimigos
-        createEnemies(this, 20);
+        const enemyCount = 20;
+        createEnemies(this, enemyCount);
+        this.enemiesTotal = enemyCount;
+
+        // Inicializa HUD
+        this.startTime = this.time.now;
+        this.hudTexts.enemiesAlive = this.add.text(10, 10, '', { fontSize: '16px', fill: '#ffffff' });
+        this.hudTexts.enemiesDefeated = this.add.text(10, 30, '', { fontSize: '16px', fill: '#ffffff' });
+        this.hudTexts.gold = this.add.text(10, 50, `Gold: ${HUD_TEXTS.gold}`, { fontSize: '16px', fill: '#ffffff' });
+        this.hudTexts.timeAlive = this.add.text(10, 70, '', { fontSize: '16px', fill: '#ffffff' });
+        this.hudTexts.life = this.add.text(10, 90, `Life: ${HUD_TEXTS.life}`, { fontSize: '16px', fill: '#ffffff' });
+        this.hudTexts.dps = this.add.text(10, 110, `DPS: ${HUD_TEXTS.dps}`, { fontSize: '16px', fill: '#ffffff' });
 
         // prevenir que os inimigos se sobreponham
         this.physics.add.collider(this.enemies, this.enemies);
@@ -59,6 +75,14 @@ class Game extends Phaser.Scene {
         separateEnemies(this);
         updateProjectiles(this);
         enforcePlayerBounds(this);
+
+        // Atualiza valores do HUD
+        const alive = this.enemies.getChildren().length;
+        const defeated = this.enemiesTotal - alive;
+        this.hudTexts.enemiesAlive.setText(`Enemies Alive: ${alive}`);
+        this.hudTexts.enemiesDefeated.setText(`Enemies Defeated: ${defeated}`);
+        const timeSeconds = Math.floor((this.time.now - this.startTime) / 1000);
+        this.hudTexts.timeAlive.setText(`Time Alive: ${timeSeconds}s`);
     }
 
 }

--- a/src/scenes/HUDConstants.js
+++ b/src/scenes/HUDConstants.js
@@ -4,7 +4,8 @@ const HUD_TEXTS = {
     round: 1,
     enemiesAlive: 1,
     life: 100,
-    dps: 1
+    dps: 1,
+    gold: 0
 };
 
 export { HUD_TEXTS };

--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -11,6 +11,7 @@ export default class TitleScreen extends Phaser.Scene {
         const enemiesAliveText = this.add.text(10, 50, `Enemies Alive: ${HUD_TEXTS.enemiesAlive}`, { fontSize: '16px', fill: '#ffffff' });
         const lifeText = this.add.text(10, 70, `Life: ${HUD_TEXTS.life}`, { fontSize: '16px', fill: '#ffffff' });
         const dpsText = this.add.text(10, 90, `DPS: ${HUD_TEXTS.dps}`, { fontSize: '16px', fill: '#ffffff' });
+        const goldText = this.add.text(10, 110, `Gold: ${HUD_TEXTS.gold}`, { fontSize: '16px', fill: '#ffffff' });
 
         // Crie um botão centralizado
         const { centerX, centerY } = this.cameras.main;
@@ -26,6 +27,7 @@ export default class TitleScreen extends Phaser.Scene {
                 HUD_TEXTS.enemiesAlive += 1;
                 HUD_TEXTS.life += 1;
                 HUD_TEXTS.dps += 1;
+                HUD_TEXTS.gold += 1;
 
                 // Atualiza os textos do HUD
                 scoreText.setText(`Score: ${HUD_TEXTS.score}`);
@@ -33,6 +35,7 @@ export default class TitleScreen extends Phaser.Scene {
                 enemiesAliveText.setText(`Enemies Alive: ${HUD_TEXTS.enemiesAlive}`);
                 lifeText.setText(`Life: ${HUD_TEXTS.life}`);
                 dpsText.setText(`DPS: ${HUD_TEXTS.dps}`);
+                goldText.setText(`Gold: ${HUD_TEXTS.gold}`);
 
                 // Inicia a cena principal do jogo
                 this.scene.start('game');


### PR DESCRIPTION
## Summary
- extend HUD constants with gold counter
- update title screen HUD to show gold
- display HUD in game scene tracking enemies, timer, life and DPS

## Testing
- `npm run build-css`
- `npm start` (manually stopped after launch)

------
https://chatgpt.com/codex/tasks/task_e_687a422a3918832c8eed1cc656810596