### PR TITLE
Add dynamic rounds and wave spawning

### DIFF
--- a/src/scenes/helpers/enemies.js
+++ b/src/scenes/helpers/enemies.js
@@ -1,9 +1,29 @@
 export function createEnemies(scene, count) {
+    const width = scene.game.config.width;
+    const height = scene.game.config.height;
     for (let i = 0; i < count; i++) {
-        const enemy = scene.add.circle(100 + i * 100, 100 + i * 100, 10, 0xFF0000, 1);
+        let x, y;
+        const edge = Phaser.Math.Between(0, 3);
+        switch (edge) {
+            case 0:
+                x = Phaser.Math.Between(0, width);
+                y = 0;
+                break;
+            case 1:
+                x = Phaser.Math.Between(0, width);
+                y = height;
+                break;
+            case 2:
+                x = 0;
+                y = Phaser.Math.Between(0, height);
+                break;
+            default:
+                x = width;
+                y = Phaser.Math.Between(0, height);
+        }
+        const enemy = scene.add.circle(x, y, 10, 0xFF0000, 1);
         scene.physics.add.existing(enemy);
         enemy.body.setVelocity(0, 0);
-        enemy.health = 20;
         scene.enemies.add(enemy);
     }
 }

--- a/src/scenes/helpers/projectiles.js
+++ b/src/scenes/helpers/projectiles.js
@@ -52,11 +52,8 @@ export function updateProjectiles(scene) {
                 projectile.target.y
             ) < 10
         ) {
-            projectile.target.health -= projectile.damage;
-            if (projectile.target.health <= 0) {
-                projectile.target.destroy();
-                scene.enemies.remove(projectile.target, true, true);
-            }
+            projectile.target.destroy();
+            scene.enemies.remove(projectile.target, true, true);
             projectile.destroy();
         }
 


### PR DESCRIPTION
## Summary
- spawn enemies in waves whose size scales with the round
- show round in the HUD
- immediately kill enemies on projectile hit
- randomize enemy spawn location

## Testing
- `npm run build-css`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e1c7430c0832cbd7bbb881d0cb9d3