### PR TITLE
Improve score loading and saving error handling

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -134,6 +134,10 @@ class Game extends Phaser.Scene {
         createdAt: firebase.firestore.FieldValue.serverTimestamp()
     }).then(() => {
         this.scene.restart();
+    })
+    .catch(err => {
+        console.error('Failed to save score', err);
+        this.scene.restart();
     });
 }
 

--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -35,7 +35,8 @@ export default class TitleScreen extends Phaser.Scene {
                 color: "#dddddd"
             }).setOrigin(0.5);
             });
-        });
+        })
+        .catch(err => console.error('Failed to load ranking', err));
         const button = this.add.text(centerX, centerY, 'START', {
             fill: '#0f0',
             fontSize: '20px',


### PR DESCRIPTION
## Summary
- catch ranking load failures in TitleScreen
- catch score save failures in Game
- run build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f52c43c50832cb7bb74c32d159d5e