### PR TITLE
Modularize Firebase setup

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,18 @@
+const firebaseConfig = {
+  apiKey: "AIzaSyDTJSH0WFZIZ77tXonpePM_k7Q3nbduSY0",
+  authDomain: "bulletrush-fun.firebaseapp.com",
+  projectId: "bulletrush-fun",
+  storageBucket: "bulletrush-fun.firebasestorage.app",
+  messagingSenderId: "23163026813",
+  appId: "1:23163026813:web:e6ffd29924e2fac884e014"
+};
+
+// firebase is loaded globally by CDN script tags in index.html
+if (!window.firebase.apps?.length) {
+  window.firebase.initializeApp(firebaseConfig);
+}
+
+const db = window.firebase.firestore();
+const firebase = window.firebase;
+
+export { firebase, db };

--- a/src/index.html
+++ b/src/index.html
@@ -18,18 +18,7 @@
   <!-- 🔥 Firebase SDK -->
   <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-firestore-compat.js"></script>
-  <script>
-    const firebaseConfig = {
-      apiKey: "AIzaSyDTJSH0WFZIZ77tXonpePM_k7Q3nbduSY0",
-    authDomain: "bulletrush-fun.firebaseapp.com",
-    projectId: "bulletrush-fun",
-    storageBucket: "bulletrush-fun.firebasestorage.app",
-    messagingSenderId: "23163026813",
-    appId: "1:23163026813:web:e6ffd29924e2fac884e014"
-    };
-    firebase.initializeApp(firebaseConfig);
-    const db = firebase.firestore();
-  </script>
+  <script type="module" src="firebase.js"></script>
 
   <!-- 🎮 Seu script Phaser -->
   <script src="main.js"></script>

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -11,7 +11,7 @@ import {
 } from "./helpers/enemies";
 import { fireProjectile, updateProjectiles } from "./helpers/projectiles";
 import { HUD_TEXTS } from "./HUDConstants";
-/* global db */ // habilita uso da variável global `db` do Firebase
+import { db, firebase } from "../firebase";
 
 
 class Game extends Phaser.Scene {

--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -1,6 +1,6 @@
 import Phaser from "phaser";
 import { HUD_TEXTS } from "./HUDConstants";
-/* global db */ // <- Isso evita erro de "db is not defined"
+import { db } from "../firebase";
 
 export default class TitleScreen extends Phaser.Scene {
     preload() {}


### PR DESCRIPTION
## Summary
- add `firebase.js` with Firestore initialization
- load Firebase setup as module in `index.html`
- import Firestore instance in game scenes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f545c0b6c832c8d41898b56b6f1c1