### PR TITLE
Fix nickname input focus on click

### DIFF
--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -40,7 +40,7 @@ export default class TitleScreen extends Phaser.Scene {
         nicknameInput.node.setAttribute('type', 'text');
         nicknameInput.node.setAttribute('placeholder', 'Nickname');
         nicknameInput.node.value = localStorage.getItem('nickname') || '';
-        nicknameInput.node.addEventListener('pointerdown', (e) => {
+        nicknameInput.node.addEventListener('click', (e) => {
             e.stopPropagation();
             nicknameInput.node.focus();
         });

--- a/tests/nicknameInput.test.js
+++ b/tests/nicknameInput.test.js
@@ -1,0 +1,45 @@
+jest.mock('phaser', () => ({
+  __esModule: true,
+  default: { Scene: class Scene {} }
+}));
+
+jest.mock('../src/firebase.js', () => {
+  const db = {
+    collection: jest.fn(function () { return this; }),
+    orderBy: jest.fn(function () { return this; }),
+    limit: jest.fn(function () { return this; }),
+    get: jest.fn(() => Promise.resolve({ forEach: jest.fn() }))
+  };
+  return {
+    __esModule: true,
+    db,
+    firebase: {}
+  };
+});
+
+import TitleScreen from '../src/scenes/TitleScreen.js';
+
+test('nickname input focuses on click', async () => {
+  const scene = new TitleScreen();
+  scene.cameras = { main: { centerX: 0, centerY: 0 } };
+
+  const input = document.createElement('input');
+  const addEventListenerSpy = jest.spyOn(input, 'addEventListener');
+  const focusSpy = jest.spyOn(input, 'focus').mockImplementation(() => {});
+
+  scene.add = {
+    text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),
+    dom: jest.fn(() => ({ node: input, setOrigin: jest.fn().mockReturnThis() }))
+  };
+  scene.input = { keyboard: { on: jest.fn() } };
+  scene.scene = { start: jest.fn() };
+
+  await scene.create();
+
+  expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+  const handler = addEventListenerSpy.mock.calls.find(call => call[0] === 'click')[1];
+  const stop = jest.fn();
+  handler({ stopPropagation: stop });
+  expect(stop).toHaveBeenCalled();
+  expect(focusSpy).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- use a standard `click` handler on the nickname input
- add regression test for nickname focus

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f6db6b7ac832ca422ea6e012ae820