### PR TITLE
Add external nickname input option

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,6 +15,9 @@
 </head>
 <body>
 
+  <input id="nickname" type="text" placeholder="Nickname"
+    style="position:absolute; top:40%; left:50%; transform:translate(-50%, -50%); z-index:1000; pointer-events:auto;" />
+
   <!-- 🔥 Firebase SDK -->
   <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-firestore-compat.js"></script>

--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -34,12 +34,21 @@ export default class TitleScreen extends Phaser.Scene {
             color: '#ffffff'
         }).setOrigin(0.5);
 
-        // Campo para digitar nickname, logo acima do botão
-        const nicknameInput = this.add.dom(centerX, centerY - 40, 'input')
-            .setOrigin(0.5);
-        nicknameInput.node.setAttribute('type', 'text');
-        nicknameInput.node.setAttribute('placeholder', 'Nickname');
-        nicknameInput.node.value = localStorage.getItem('nickname') || '';
+        let domElement = document.getElementById('nickname');
+        let nicknameInput;
+
+        if (domElement) {
+            nicknameInput = { node: domElement };
+            domElement.value = localStorage.getItem('nickname') || '';
+        } else {
+            // Campo para digitar nickname criado via Phaser DOM
+            nicknameInput = this.add.dom(centerX, centerY - 40, 'input')
+                .setOrigin(0.5);
+            nicknameInput.node.setAttribute('type', 'text');
+            nicknameInput.node.setAttribute('placeholder', 'Nickname');
+            nicknameInput.node.value = localStorage.getItem('nickname') || '';
+        }
+
         nicknameInput.node.addEventListener('click', (e) => {
             e.stopPropagation();
             nicknameInput.node.focus();
@@ -55,7 +64,16 @@ export default class TitleScreen extends Phaser.Scene {
             borderRadius: '4px',
             width: '220px',
             textAlign: 'center',
-            cursor: 'text'
+            cursor: 'text',
+            pointerEvents: 'auto',
+            zIndex: 1000
+        });
+
+        nicknameInput.node.addEventListener('focus', () => {
+            this.input.keyboard.enabled = false;
+        });
+        nicknameInput.node.addEventListener('blur', () => {
+            this.input.keyboard.enabled = true;
         });
         // 🔥 Mostrar Top 10 do Firebase
         let startY = 50;

--- a/tests/externalInput.test.js
+++ b/tests/externalInput.test.js
@@ -1,0 +1,40 @@
+import TitleScreen from '../src/scenes/TitleScreen.js';
+
+jest.mock('phaser', () => ({
+  __esModule: true,
+  default: { Scene: class Scene {} }
+}));
+
+jest.mock('../src/firebase.js', () => {
+  const db = {
+    collection: jest.fn(() => ({
+      orderBy: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          get: jest.fn(() => Promise.resolve({ forEach: jest.fn() }))
+        }))
+      }))
+    }))
+  };
+  return { __esModule: true, db, firebase: {} };
+});
+
+test('uses external nickname input if available', async () => {
+  const external = document.createElement('input');
+  external.id = 'nickname';
+  document.body.appendChild(external);
+
+  const scene = new TitleScreen();
+  scene.cameras = { main: { centerX: 0, centerY: 0 } };
+  scene.add = {
+    text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),
+    dom: jest.fn()
+  };
+  scene.input = { keyboard: { on: jest.fn(), enabled: true } };
+  scene.scene = { start: jest.fn() };
+
+  await scene.create();
+
+  expect(scene.add.dom).not.toHaveBeenCalled();
+  expect(external.style.pointerEvents).toBe('auto');
+  document.body.removeChild(external);
+});

--- a/tests/nicknameInput.test.js
+++ b/tests/nicknameInput.test.js
@@ -31,7 +31,7 @@ test('nickname input focuses on click', async () => {
     text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),
     dom: jest.fn(() => ({ node: input, setOrigin: jest.fn().mockReturnThis() }))
   };
-  scene.input = { keyboard: { on: jest.fn() } };
+  scene.input = { keyboard: { on: jest.fn(), enabled: true } };
   scene.scene = { start: jest.fn() };
 
   await scene.create();
@@ -42,4 +42,15 @@ test('nickname input focuses on click', async () => {
   handler({ stopPropagation: stop });
   expect(stop).toHaveBeenCalled();
   expect(focusSpy).toHaveBeenCalled();
+
+  // focus event disables keyboard
+  addEventListenerSpy.mock.calls.find(call => call[0] === 'focus')[1]();
+  expect(scene.input.keyboard.enabled).toBe(false);
+
+  // blur re-enables
+  addEventListenerSpy.mock.calls.find(call => call[0] === 'blur')[1]();
+  expect(scene.input.keyboard.enabled).toBe(true);
+
+  // pointer events style is applied
+  expect(input.style.pointerEvents).toBe('auto');
 });


### PR DESCRIPTION
## Summary
- support a DOM input outside Phaser to set nickname
- keep focus/blur events from stealing keyboard input
- add pointer-events and z-index styling
- test internal and external nickname input handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f7268f960832c823e49241143ba0d