### PR TITLE
Hide nickname input when starting game

### DIFF
--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -112,6 +112,8 @@ export default class TitleScreen extends Phaser.Scene {
                     nicknameInput.node.value = value;
                 }
                 localStorage.setItem('nickname', value);
+                // Hide the nickname input when starting the game
+                nicknameInput.node.style.display = 'none';
 
                 // Reinicia valores importantes do HUD ao iniciar o jogo
                 HUD_TEXTS.life = 100;


### PR DESCRIPTION
## Summary
- hide nickname input in TitleScreen before switching to game scene

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880b1312e80832c8aaf75dda41320df