### PR TITLE
Remove leftover nickname hint

### DIFF
--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -28,11 +28,6 @@ export default class TitleScreen extends Phaser.Scene {
         // Crie um botão centralizado
         const { centerX, centerY } = this.cameras.main;
 
-        // Texto explicando o campo de nickname
-        this.add.text(centerX, centerY - 80, 'Digite seu Nickname', {
-            fontSize: '24px',
-            color: '#ffffff'
-        }).setOrigin(0.5);
 
         let domElement = document.getElementById('nickname');
         let nicknameInput;


### PR DESCRIPTION
## Summary
- clean up old "Digite seu Nickname" text from TitleScreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880b612a210832ca560b4f189894d1d