### PR TITLE
Limit nickname attempts and add test

### DIFF
--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -6,10 +6,11 @@ export default class TitleScreen extends Phaser.Scene {
     preload() {}
 
     async generateDefaultNickname() {
-        let base = 'bob';
-        let candidate = base;
-        let idx = 0;
-        while (true) {
+        const base = 'bob';
+        const maxAttempts = 5;
+
+        for (let idx = 0; idx < maxAttempts; idx++) {
+            const candidate = idx === 0 ? base : `${base}${idx}`;
             const snap = await db
                 .collection('scores')
                 .where('nickname', '==', candidate)
@@ -18,9 +19,9 @@ export default class TitleScreen extends Phaser.Scene {
             if (snap.empty) {
                 return candidate;
             }
-            idx += 1;
-            candidate = `${base}${idx}`;
         }
+
+        return `${base}-${Date.now()}`;
     }
 
     async create() {

--- a/tests/generateDefaultNickname.test.js
+++ b/tests/generateDefaultNickname.test.js
@@ -1,0 +1,32 @@
+jest.mock('phaser', () => ({
+  __esModule: true,
+  default: { Scene: class Scene {} }
+}));
+
+jest.mock('../src/firebase.js', () => {
+  const getMock = jest.fn();
+  const db = {
+    collection: jest.fn(() => ({
+      where: jest.fn(() => ({
+        limit: jest.fn(() => ({
+          get: getMock
+        }))
+      }))
+    }))
+  };
+  return { __esModule: true, db, firebase: {}, getMock };
+});
+
+import { getMock } from '../src/firebase.js';
+
+import TitleScreen from '../src/scenes/TitleScreen.js';
+
+test('generateDefaultNickname returns unique value after max attempts', async () => {
+  const scene = new TitleScreen();
+  getMock.mockResolvedValue({ empty: false });
+
+  const nickname = await scene.generateDefaultNickname();
+
+  expect(getMock).toHaveBeenCalledTimes(5);
+  expect(nickname.startsWith('bob-')).toBe(true);
+});


### PR DESCRIPTION
## Summary
- check only a few nicknames when generating the default name
- fallback to timestamp suffix when all options fail
- test nickname generation when the limit is reached

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880c7ff4238832c869f9f8f4a5771ea