### PR TITLE
Add empty ranking message

### DIFF
--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -88,13 +88,20 @@ export default class TitleScreen extends Phaser.Scene {
                 color: "#ffffff"
             }).setOrigin(0.5);
 
-            snapshot.forEach((doc, index) => {
-                const data = doc.data();
-                this.add.text(centerX, startY + index * 25, `${index + 1}. ${data.nickname} - ${data.time}s`, {
-                    fontSize: "16px",
-                    color: "#dddddd"
+            if (snapshot.empty) {
+                this.add.text(centerX, startY, 'No scores yet', {
+                    fontSize: '16px',
+                    color: '#dddddd'
                 }).setOrigin(0.5);
-            });
+            } else {
+                snapshot.forEach((doc, index) => {
+                    const data = doc.data();
+                    this.add.text(centerX, startY + index * 25, `${index + 1}. ${data.nickname} - ${data.time}s`, {
+                        fontSize: "16px",
+                        color: "#dddddd"
+                    }).setOrigin(0.5);
+                });
+            }
         } catch (err) {
             console.error('Failed to load ranking', err);
         }

--- a/tests/noScoresMessage.test.js
+++ b/tests/noScoresMessage.test.js
@@ -1,0 +1,33 @@
+jest.mock('phaser', () => ({
+  __esModule: true,
+  default: { Scene: class Scene {} }
+}));
+
+jest.mock('../src/firebase.js', () => {
+  const db = {
+    collection: jest.fn(function () { return this; }),
+    orderBy: jest.fn(function () { return this; }),
+    limit: jest.fn(function () { return this; }),
+    get: jest.fn(() => Promise.resolve({ empty: true, forEach: jest.fn() }))
+  };
+  return { __esModule: true, db, firebase: {} };
+});
+
+import TitleScreen from '../src/scenes/TitleScreen.js';
+
+test('shows message when no scores', async () => {
+  const scene = new TitleScreen();
+  scene.cameras = { main: { centerX: 0, centerY: 0 } };
+  const input = document.createElement('input');
+  scene.add = {
+    text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),
+    dom: jest.fn(() => ({ node: input, setOrigin: jest.fn().mockReturnThis() }))
+  };
+  scene.input = { keyboard: { on: jest.fn(), enabled: true } };
+  scene.scene = { start: jest.fn() };
+
+  await scene.create();
+
+  const texts = scene.add.text.mock.calls.map(c => c[2]);
+  expect(texts).toContain('No scores yet');
+});


### PR DESCRIPTION
## Summary
- show a fallback message when no ranking entries exist
- test that the message is displayed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6881fd1a7968832cba50934a6eaa47c3