### PR TITLE
Fix ranking display index

### DIFF
--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -94,12 +94,14 @@ export default class TitleScreen extends Phaser.Scene {
                     color: '#dddddd'
                 }).setOrigin(0.5);
             } else {
-                snapshot.forEach((doc, index) => {
+                let idx = 0;
+                snapshot.forEach((doc) => {
                     const data = doc.data();
-                    this.add.text(centerX, startY + index * 25, `${index + 1}. ${data.nickname} - ${data.time}s`, {
+                    this.add.text(centerX, startY + idx * 25, `${idx + 1}. ${data.nickname} - ${data.time}s`, {
                         fontSize: "16px",
                         color: "#dddddd"
                     }).setOrigin(0.5);
+                    idx += 1;
                 });
             }
         } catch (err) {

--- a/tests/rankingDisplay.test.js
+++ b/tests/rankingDisplay.test.js
@@ -13,7 +13,7 @@ jest.mock('../src/firebase.js', () => {
     orderBy: jest.fn(function () { return this; }),
     limit: jest.fn(function () { return this; }),
     get: jest.fn(() => Promise.resolve({
-      forEach: (cb) => fakeDocs.forEach((doc, idx) => cb(doc, idx))
+      forEach: (cb) => fakeDocs.forEach((doc) => cb(doc))
     }))
   };
   return { __esModule: true, db, firebase: {} };


### PR DESCRIPTION
## Summary
- properly index leaderboard entries when iterating Firestore snapshots
- adjust ranking display test to match Firestore forEach signature

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688207d2c250832ca93637c19b1e8c9e