### PR TITLE
Add shooter enemies to game

### DIFF
--- a/src/scenes/helpers/enemies.js
+++ b/src/scenes/helpers/enemies.js
@@ -1,3 +1,5 @@
+import { fireShooterProjectile } from "./projectiles";
+
 export function createEnemies(scene, count) {
     const width = scene.game.config.width;
     const height = scene.game.config.height;
@@ -60,4 +62,49 @@ export function separateEnemies(scene) {
             }
         }
     }
+}
+
+export function createShooterEnemies(scene, count) {
+    const width = scene.game.config.width;
+    const height = scene.game.config.height;
+
+    for (let i = 0; i < count; i++) {
+        const x = Phaser.Math.Between(0, width);
+        const y = Phaser.Math.Between(0, height);
+        const shooter = scene.add.circle(x, y, 10, 0xFFFF00, 1);
+        scene.physics.add.existing(shooter);
+        shooter.body.setVelocity(0, 0);
+        scene.shooters.add(shooter);
+
+        if (scene.time) {
+            scene.time.addEvent({
+                delay: 1500,
+                callback: () => fireShooterProjectile(scene, shooter),
+                loop: true
+            });
+        }
+    }
+}
+
+export function updateShooterEnemies(scene) {
+    const playerX = scene.player.x;
+    const playerY = scene.player.y;
+    scene.shooters.getChildren().forEach(shooter => {
+        const dist = Phaser.Math.Distance.Between(shooter.x, shooter.y, playerX, playerY);
+        const angle = Phaser.Math.Angle.Between(shooter.x, shooter.y, playerX, playerY);
+
+        if (dist > 210) {
+            shooter.body.setVelocity(
+                Math.cos(angle) * scene.enemySpeed,
+                Math.sin(angle) * scene.enemySpeed
+            );
+        } else if (dist < 190) {
+            shooter.body.setVelocity(
+                -Math.cos(angle) * scene.enemySpeed,
+                -Math.sin(angle) * scene.enemySpeed
+            );
+        } else {
+            shooter.body.setVelocity(0, 0);
+        }
+    });
 }

--- a/src/scenes/helpers/projectiles.js
+++ b/src/scenes/helpers/projectiles.js
@@ -63,3 +63,26 @@ export function updateProjectiles(scene) {
         }
     }, scene);
 }
+
+export function fireShooterProjectile(scene, shooter) {
+    const projectile = scene.add.circle(shooter.x, shooter.y, 4, 0xFFA500, 1);
+    scene.physics.add.existing(projectile);
+    const angle = Phaser.Math.Angle.Between(shooter.x, shooter.y, scene.player.x, scene.player.y);
+    projectile.body.setVelocity(
+        Math.cos(angle) * scene.enemyBulletSpeed,
+        Math.sin(angle) * scene.enemyBulletSpeed
+    );
+    scene.enemyBullets.add(projectile);
+}
+
+export function updateEnemyBullets(scene) {
+    scene.enemyBullets.getChildren().forEach(projectile => {
+        const { width, height } = scene.game.config;
+        if (
+            projectile.x < 0 || projectile.x > width ||
+            projectile.y < 0 || projectile.y > height
+        ) {
+            projectile.destroy();
+        }
+    });
+}

--- a/tests/shooters.test.js
+++ b/tests/shooters.test.js
@@ -1,0 +1,62 @@
+jest.mock('phaser', () => ({
+  __esModule: true,
+  default: {
+    Scene: class Scene {},
+    Math: { Between: jest.fn(() => 0) }
+  }
+}));
+
+jest.mock('../src/firebase.js', () => ({
+  __esModule: true,
+  db: {},
+  firebase: {}
+}));
+
+import { createShooterEnemies as realCreateShooterEnemies } from '../src/scenes/helpers/enemies.js';
+import Phaser from 'phaser';
+global.Phaser = Phaser;
+
+
+test('createShooterEnemies spawns shooters and timers', () => {
+  const addCircle = jest.fn(() => ({}));
+  const scene = {
+    add: { circle: addCircle },
+    physics: { add: { existing: jest.fn(obj => { obj.body = { setVelocity: jest.fn() }; }) } },
+    shooters: { add: jest.fn(), getChildren: jest.fn(() => []) },
+    time: { addEvent: jest.fn() },
+    game: { config: { width: 800, height: 600 } },
+    player: { x: 0, y: 0 }
+  };
+  realCreateShooterEnemies(scene, 2);
+  expect(scene.shooters.add).toHaveBeenCalledTimes(2);
+  expect(scene.time.addEvent).toHaveBeenCalledTimes(2);
+  expect(scene.time.addEvent.mock.calls[0][0].delay).toBe(1500);
+});
+
+
+test('spawnWave spawns shooters equal to current round', async () => {
+  jest.resetModules();
+  jest.doMock('../src/scenes/helpers/enemies.js', () => ({
+    __esModule: true,
+    createEnemies: jest.fn(),
+    updateEnemies: jest.fn(),
+    separateEnemies: jest.fn(),
+    createShooterEnemies: jest.fn(),
+    updateShooterEnemies: jest.fn()
+  }));
+
+  const { default: Game } = await import('../src/scenes/Game.js');
+  const enemies = await import('../src/scenes/helpers/enemies.js');
+  const { createEnemies, createShooterEnemies } = enemies;
+
+  const game = new Game();
+  game.enemies = {};
+  game.shooters = {};
+  game.currentRound = 3;
+  game.enemiesTotal = 0;
+
+  game.spawnWave();
+  expect(createEnemies).toHaveBeenCalledWith(game, 15);
+  expect(createShooterEnemies).toHaveBeenCalledWith(game, 3);
+  expect(game.enemiesTotal).toBe(18);
+});


### PR DESCRIPTION
## Summary
- add shooter enemy logic and enemy bullets
- keep shooters near the player and make them fire every 1500ms
- spawn shooters each wave and handle their collisions
- add unit tests for shooter creation and wave spawning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68834f364180832c82a529b43b90fbe3