### PR TITLE
Fix shooter bullet velocity

### DIFF
--- a/src/scenes/helpers/projectiles.js
+++ b/src/scenes/helpers/projectiles.js
@@ -67,11 +67,22 @@ export function updateProjectiles(scene) {
 export function fireShooterProjectile(scene, shooter) {
     const projectile = scene.add.circle(shooter.x, shooter.y, 4, 0xFFA500, 1);
     scene.physics.add.existing(projectile);
-    const angle = Phaser.Math.Angle.Between(shooter.x, shooter.y, scene.player.x, scene.player.y);
-    projectile.body.setVelocity(
-        Math.cos(angle) * scene.enemyBulletSpeed,
-        Math.sin(angle) * scene.enemyBulletSpeed
+
+    const angle = Phaser.Math.Angle.Between(
+        shooter.x,
+        shooter.y,
+        scene.player.x,
+        scene.player.y
     );
+
+    // Ensure the bullet travels with a fixed velocity towards the
+    // player's position at the moment of the shot.
+    scene.physics.velocityFromRotation(
+        angle,
+        scene.enemyBulletSpeed,
+        projectile.body.velocity
+    );
+
     scene.enemyBullets.add(projectile);
 }
 


### PR DESCRIPTION
## Summary
- ensure shooter projectiles move toward the player's last position

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688353dbbe94832c9a6eb77398baf0ed