### PR TITLE
Improve enemy projectile firing

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -26,6 +26,7 @@ class Game extends Phaser.Scene {
         this.playerSpeed = 150;
         this.enemySpeed = 150;
         this.enemyBulletSpeed = 200;
+        this.playerBulletSpeed = 300;
         this.playerVelocityX = 0;
         this.playerVelocityY = 0;
         this.cursors = null;

--- a/src/scenes/helpers/projectiles.js
+++ b/src/scenes/helpers/projectiles.js
@@ -79,7 +79,7 @@ export function fireShooterProjectile(scene, shooter) {
     // player's position at the moment of the shot.
     scene.physics.velocityFromRotation(
         angle,
-        scene.enemyBulletSpeed,
+        scene.playerBulletSpeed,
         projectile.body.velocity
     );
 


### PR DESCRIPTION
## Summary
- add `playerBulletSpeed` to scene parameters
- fire shooter bullets using the player's projectile speed
- keep destroying enemy projectiles when they leave the screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883576f2f5c832cbb7384913316403b