### PR TITLE
Fix player targeting shooter enemies

### DIFF
--- a/src/scenes/helpers/projectiles.js
+++ b/src/scenes/helpers/projectiles.js
@@ -1,5 +1,8 @@
 export function fireProjectile(scene) {
-    if (scene.enemies.getChildren().length === 0) {
+    if (
+        scene.enemies.getChildren().length === 0 &&
+        scene.shooters.getChildren().length === 0
+    ) {
         return;
     }
 
@@ -8,8 +11,17 @@ export function fireProjectile(scene) {
 
     let closestEnemy = null;
     let shortestDistSq = Infinity;
-    scene.enemies.getChildren().forEach(enemy => {
-        const distSq = Phaser.Math.Distance.Squared(enemy.x, enemy.y, playerX, playerY);
+    const potentialTargets = [
+        ...scene.enemies.getChildren(),
+        ...scene.shooters.getChildren()
+    ];
+    potentialTargets.forEach(enemy => {
+        const distSq = Phaser.Math.Distance.Squared(
+            enemy.x,
+            enemy.y,
+            playerX,
+            playerY
+        );
         if (distSq < shortestDistSq) {
             shortestDistSq = distSq;
             closestEnemy = enemy;
@@ -54,6 +66,7 @@ export function updateProjectiles(scene) {
         ) {
             projectile.target.destroy();
             scene.enemies.remove(projectile.target, true, true);
+            scene.shooters.remove(projectile.target, true, true);
             projectile.destroy();
         }
 


### PR DESCRIPTION
## Summary
- allow projectile to target shooter enemies
- destroy shooter enemies properly when hit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883621dcab8832c960cdb8fde2f62d0