### PR TITLE
Fix shooter timer persistence

### DIFF
--- a/src/scenes/helpers/enemies.js
+++ b/src/scenes/helpers/enemies.js
@@ -77,7 +77,7 @@ export function createShooterEnemies(scene, count) {
         scene.shooters.add(shooter);
 
         if (scene.time) {
-            scene.time.addEvent({
+            shooter.shootEvent = scene.time.addEvent({
                 delay: 1500,
                 callback: () => fireShooterProjectile(scene, shooter),
                 loop: true

--- a/src/scenes/helpers/projectiles.js
+++ b/src/scenes/helpers/projectiles.js
@@ -64,6 +64,9 @@ export function updateProjectiles(scene) {
                 projectile.target.y
             ) < 100
         ) {
+            if (projectile.target.shootEvent) {
+                scene.time.removeEvent(projectile.target.shootEvent);
+            }
             projectile.target.destroy();
             scene.enemies.remove(projectile.target, true, true);
             scene.shooters.remove(projectile.target, true, true);

--- a/tests/shooters.test.js
+++ b/tests/shooters.test.js
@@ -2,7 +2,11 @@ jest.mock('phaser', () => ({
   __esModule: true,
   default: {
     Scene: class Scene {},
-    Math: { Between: jest.fn(() => 0) }
+    Math: {
+      Between: jest.fn(() => 0),
+      Angle: { Between: jest.fn(() => 0) },
+      Distance: { Squared: jest.fn(() => 0) }
+    }
   }
 }));
 
@@ -13,17 +17,23 @@ jest.mock('../src/firebase.js', () => ({
 }));
 
 import { createShooterEnemies as realCreateShooterEnemies } from '../src/scenes/helpers/enemies.js';
+import { updateProjectiles } from '../src/scenes/helpers/projectiles.js';
 import Phaser from 'phaser';
 global.Phaser = Phaser;
 
 
 test('createShooterEnemies spawns shooters and timers', () => {
-  const addCircle = jest.fn(() => ({}));
+  const created = [];
+  const addCircle = jest.fn(() => {
+    const obj = {};
+    created.push(obj);
+    return obj;
+  });
   const scene = {
     add: { circle: addCircle },
     physics: { add: { existing: jest.fn(obj => { obj.body = { setVelocity: jest.fn() }; }) } },
     shooters: { add: jest.fn(), getChildren: jest.fn(() => []) },
-    time: { addEvent: jest.fn() },
+    time: { addEvent: jest.fn(() => ({})) },
     game: { config: { width: 800, height: 600 } },
     player: { x: 0, y: 0 }
   };
@@ -31,6 +41,34 @@ test('createShooterEnemies spawns shooters and timers', () => {
   expect(scene.shooters.add).toHaveBeenCalledTimes(2);
   expect(scene.time.addEvent).toHaveBeenCalledTimes(2);
   expect(scene.time.addEvent.mock.calls[0][0].delay).toBe(1500);
+  created.forEach(shooter => {
+    expect(shooter.shootEvent).toBeDefined();
+  });
+});
+
+test('destroying shooter removes its timer', () => {
+  const shooter = { x: 0, y: 0, active: true, destroy: jest.fn(), shootEvent: {} };
+  const projectile = {
+    active: true,
+    target: shooter,
+    x: 0,
+    y: 0,
+    body: { setVelocity: jest.fn() },
+    destroy: jest.fn()
+  };
+  const scene = {
+    time: { removeEvent: jest.fn() },
+    enemies: { remove: jest.fn(), getChildren: jest.fn(() => []) },
+    shooters: { remove: jest.fn(), getChildren: jest.fn(() => []) },
+    projectiles: { children: { each: (fn, ctx) => fn.call(ctx, projectile) } },
+    projectileSpeed: 100,
+    game: { config: { width: 800, height: 600 } }
+  };
+  updateProjectiles(scene);
+  expect(scene.time.removeEvent).toHaveBeenCalledWith(shooter.shootEvent);
+  expect(shooter.destroy).toHaveBeenCalled();
+  expect(projectile.destroy).toHaveBeenCalled();
+  expect(scene.shooters.remove).toHaveBeenCalledWith(shooter, true, true);
 });
 
 


### PR DESCRIPTION
## Summary
- assign a timer reference when creating shooter enemies
- remove the timer event when a shooter is destroyed
- cover shooter timer cleanup with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883641316c0832cbe5750ab753781bb