### PR TITLE
Add registration page and buttons

### DIFF
--- a/src/login.html
+++ b/src/login.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Login - Bullet Rush</title>
+  <link rel="icon" type="image/png" href="bulletrush.png" />
+  <link rel="stylesheet" href="main.scss">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+      background-color: #000;
+      color: #fff;
+    }
+  </style>
+</head>
+<body>
+  <p>Página de login em construção.</p>
+</body>
+</html>

--- a/src/register.html
+++ b/src/register.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Registrar - Bullet Rush</title>
+  <link rel="icon" type="image/png" href="bulletrush.png" />
+  <link rel="stylesheet" href="main.scss">
+  <style>
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+      background-color: #000;
+      color: #fff;
+    }
+    input, button {
+      margin: 8px;
+      padding: 8px 12px;
+      font-size: 16px;
+    }
+  </style>
+</head>
+<body>
+  <input id="reg-nickname" type="text" placeholder="Nickname" />
+  <input id="reg-password" type="password" placeholder="Senha" />
+  <button id="reg-submit">Registrar</button>
+
+  <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-firestore-compat.js"></script>
+  <script type="module" src="firebase.js"></script>
+  <script type="module" src="register.js"></script>
+</body>
+</html>

--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,33 @@
+import { db } from './firebase';
+
+const nickInput = document.getElementById('reg-nickname');
+const passInput = document.getElementById('reg-password');
+const submitBtn = document.getElementById('reg-submit');
+
+async function hashPassword(password) {
+  const enc = new TextEncoder().encode(password);
+  const buf = await crypto.subtle.digest('SHA-256', enc);
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+submitBtn.addEventListener('click', async () => {
+  const nickname = nickInput.value.trim();
+  const password = passInput.value;
+
+  if (!nickname || !password) {
+    alert('Preencha nickname e senha');
+    return;
+  }
+
+  try {
+    const hashed = await hashPassword(password);
+    await db.collection('users').add({ nickname, password: hashed });
+    alert('Registrado com sucesso!');
+    window.location.href = 'index.html';
+  } catch (err) {
+    console.error('Falha ao registrar', err);
+    alert('Erro ao registrar');
+  }
+});

--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -133,6 +133,32 @@ export default class TitleScreen extends Phaser.Scene {
                 this.scene.start('game');
             });
 
+        // Botão para página de Login
+        const loginBtn = this.add.text(centerX, centerY + 40, 'Login', {
+            fill: '#0f0',
+            fontSize: '18px'
+        })
+            .setOrigin(0.5)
+            .setInteractive({ useHandCursor: true })
+            .on('pointerover', () => loginBtn.setTint(0xcccccc))
+            .on('pointerout', () => loginBtn.clearTint())
+            .on('pointerdown', () => {
+                window.location.href = 'login.html';
+            });
+
+        // Botão para página de registro
+        const registerBtn = this.add.text(centerX, centerY + 80, 'Registrar', {
+            fill: '#0f0',
+            fontSize: '18px'
+        })
+            .setOrigin(0.5)
+            .setInteractive({ useHandCursor: true })
+            .on('pointerover', () => registerBtn.setTint(0xcccccc))
+            .on('pointerout', () => registerBtn.clearTint())
+            .on('pointerdown', () => {
+                window.location.href = 'register.html';
+            });
+
         // Permitir que a tecla ENTER também inicie o jogo
         this.input.keyboard.on('keydown-ENTER', () => button.emit('pointerdown'));
     }


### PR DESCRIPTION
## Summary
- add buttons to TitleScreen for login and registration
- add simple registration page and script
- include placeholder login page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884ce7d4ba8832ca88237176c4dae68