### PR TITLE
Add Google login with user persistence

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -15,5 +15,7 @@ if (!window.firebase.apps?.length) {
 
 const db = window.firebase.firestore();
 const firebase = window.firebase;
+const auth = window.firebase.auth();
+const googleProvider = new window.firebase.auth.GoogleAuthProvider();
 
-export { firebase, db };
+export { firebase, db, auth, googleProvider };

--- a/src/index.html
+++ b/src/index.html
@@ -34,10 +34,13 @@
 <body>
   <input id="nickname" type="text" placeholder="Nickname"
     style="position:absolute; top:40%; left:50%; transform:translate(-50%, -50%); z-index:1000; pointer-events:auto;" />
+  <button id="google-login" style="position:absolute; top:10px; right:10px; z-index:1000;">Login with Google</button>
+  <div id="user-info" style="position:absolute; top:10px; right:140px; z-index:1000; display:flex; align-items:center; gap:4px;"></div>
 
   <!-- 🔥 Firebase SDK -->
   <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.3.0/firebase-auth-compat.js"></script>
   <script type="module" src="firebase.js"></script>
 
   <!-- 👾 Phaser -->

--- a/tests/externalInput.test.js
+++ b/tests/externalInput.test.js
@@ -15,7 +15,13 @@ jest.mock('../src/firebase.js', () => {
       }))
     }))
   };
-  return { __esModule: true, db, firebase: {} };
+  return {
+    __esModule: true,
+    db,
+    firebase: {},
+    auth: { onAuthStateChanged: jest.fn() },
+    googleProvider: {}
+  };
 });
 
 test('uses external nickname input if available', async () => {

--- a/tests/generateDefaultNickname.test.js
+++ b/tests/generateDefaultNickname.test.js
@@ -14,7 +14,14 @@ jest.mock('../src/firebase.js', () => {
       }))
     }))
   };
-  return { __esModule: true, db, firebase: {}, getMock };
+  return {
+    __esModule: true,
+    db,
+    firebase: {},
+    getMock,
+    auth: { onAuthStateChanged: jest.fn() },
+    googleProvider: {}
+  };
 });
 
 import { getMock } from '../src/firebase.js';

--- a/tests/nicknameInput.test.js
+++ b/tests/nicknameInput.test.js
@@ -13,7 +13,9 @@ jest.mock('../src/firebase.js', () => {
   return {
     __esModule: true,
     db,
-    firebase: {}
+    firebase: {},
+    auth: { onAuthStateChanged: jest.fn() },
+    googleProvider: {}
   };
 });
 

--- a/tests/noScoresMessage.test.js
+++ b/tests/noScoresMessage.test.js
@@ -10,7 +10,13 @@ jest.mock('../src/firebase.js', () => {
     limit: jest.fn(function () { return this; }),
     get: jest.fn(() => Promise.resolve({ empty: true, forEach: jest.fn() }))
   };
-  return { __esModule: true, db, firebase: {} };
+  return {
+    __esModule: true,
+    db,
+    firebase: {},
+    auth: { onAuthStateChanged: jest.fn() },
+    googleProvider: {}
+  };
 });
 
 import TitleScreen from '../src/scenes/TitleScreen.js';

--- a/tests/rankingDisplay.test.js
+++ b/tests/rankingDisplay.test.js
@@ -16,7 +16,13 @@ jest.mock('../src/firebase.js', () => {
       forEach: (cb) => fakeDocs.forEach((doc) => cb(doc))
     }))
   };
-  return { __esModule: true, db, firebase: {} };
+  return {
+    __esModule: true,
+    db,
+    firebase: {},
+    auth: { onAuthStateChanged: jest.fn() },
+    googleProvider: {}
+  };
 });
 
 import TitleScreen from '../src/scenes/TitleScreen.js';

--- a/tests/shooters.test.js
+++ b/tests/shooters.test.js
@@ -13,7 +13,9 @@ jest.mock('phaser', () => ({
 jest.mock('../src/firebase.js', () => ({
   __esModule: true,
   db: {},
-  firebase: {}
+  firebase: {},
+  auth: { onAuthStateChanged: jest.fn() },
+  googleProvider: {}
 }));
 
 import { createShooterEnemies as realCreateShooterEnemies } from '../src/scenes/helpers/enemies.js';

--- a/tests/titleScreen.test.js
+++ b/tests/titleScreen.test.js
@@ -6,7 +6,9 @@ jest.mock('phaser', () => ({
 jest.mock('../src/firebase.js', () => ({
   __esModule: true,
   db: {},
-  firebase: {}
+  firebase: {},
+  auth: { onAuthStateChanged: jest.fn() },
+  googleProvider: {}
 }));
 
 import TitleScreen from '../src/scenes/TitleScreen.js';


### PR DESCRIPTION
## Summary
- initialize Firebase Auth provider
- include Google login button and user display
- store logged in user's displayName in Firestore
- adjust tests for new firebase exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884e42b8ad0832c86a52a1393b380f9