### PR TITLE
Track enemies killed and user playtime

### DIFF
--- a/tests/externalInput.test.js
+++ b/tests/externalInput.test.js
@@ -12,14 +12,15 @@ jest.mock('../src/firebase.js', () => {
         limit: jest.fn(() => ({
           get: jest.fn(() => Promise.resolve({ forEach: jest.fn() }))
         }))
-      }))
+      })),
+      doc: jest.fn(() => ({ set: jest.fn() }))
     }))
   };
   return {
     __esModule: true,
     db,
     firebase: {},
-    auth: { onAuthStateChanged: jest.fn() },
+    auth: { onAuthStateChanged: jest.fn(), currentUser: null },
     googleProvider: {}
   };
 });

--- a/tests/generateDefaultNickname.test.js
+++ b/tests/generateDefaultNickname.test.js
@@ -11,7 +11,8 @@ jest.mock('../src/firebase.js', () => {
         limit: jest.fn(() => ({
           get: getMock
         }))
-      }))
+      })),
+      doc: jest.fn(() => ({ set: jest.fn() }))
     }))
   };
   return {
@@ -19,7 +20,7 @@ jest.mock('../src/firebase.js', () => {
     db,
     firebase: {},
     getMock,
-    auth: { onAuthStateChanged: jest.fn() },
+    auth: { onAuthStateChanged: jest.fn(), currentUser: null },
     googleProvider: {}
   };
 });

--- a/tests/nicknameInput.test.js
+++ b/tests/nicknameInput.test.js
@@ -8,13 +8,14 @@ jest.mock('../src/firebase.js', () => {
     collection: jest.fn(function () { return this; }),
     orderBy: jest.fn(function () { return this; }),
     limit: jest.fn(function () { return this; }),
-    get: jest.fn(() => Promise.resolve({ forEach: jest.fn() }))
+    get: jest.fn(() => Promise.resolve({ forEach: jest.fn() })),
+    doc: jest.fn(() => ({ set: jest.fn() }))
   };
   return {
     __esModule: true,
     db,
     firebase: {},
-    auth: { onAuthStateChanged: jest.fn() },
+    auth: { onAuthStateChanged: jest.fn(), currentUser: null },
     googleProvider: {}
   };
 });

--- a/tests/noScoresMessage.test.js
+++ b/tests/noScoresMessage.test.js
@@ -8,13 +8,14 @@ jest.mock('../src/firebase.js', () => {
     collection: jest.fn(function () { return this; }),
     orderBy: jest.fn(function () { return this; }),
     limit: jest.fn(function () { return this; }),
-    get: jest.fn(() => Promise.resolve({ empty: true, forEach: jest.fn() }))
+    get: jest.fn(() => Promise.resolve({ empty: true, forEach: jest.fn() })),
+    doc: jest.fn(() => ({ set: jest.fn() }))
   };
   return {
     __esModule: true,
     db,
     firebase: {},
-    auth: { onAuthStateChanged: jest.fn() },
+    auth: { onAuthStateChanged: jest.fn(), currentUser: null },
     googleProvider: {}
   };
 });

--- a/tests/rankingDisplay.test.js
+++ b/tests/rankingDisplay.test.js
@@ -14,13 +14,14 @@ jest.mock('../src/firebase.js', () => {
     limit: jest.fn(function () { return this; }),
     get: jest.fn(() => Promise.resolve({
       forEach: (cb) => fakeDocs.forEach((doc) => cb(doc))
-    }))
+    })),
+    doc: jest.fn(() => ({ set: jest.fn() }))
   };
   return {
     __esModule: true,
     db,
     firebase: {},
-    auth: { onAuthStateChanged: jest.fn() },
+    auth: { onAuthStateChanged: jest.fn(), currentUser: null },
     googleProvider: {}
   };
 });

--- a/tests/shooters.test.js
+++ b/tests/shooters.test.js
@@ -12,9 +12,9 @@ jest.mock('phaser', () => ({
 
 jest.mock('../src/firebase.js', () => ({
   __esModule: true,
-  db: {},
+  db: { collection: jest.fn(() => ({ doc: jest.fn(() => ({ set: jest.fn() })) })) },
   firebase: {},
-  auth: { onAuthStateChanged: jest.fn() },
+  auth: { onAuthStateChanged: jest.fn(), currentUser: null },
   googleProvider: {}
 }));
 

--- a/tests/titleScreen.test.js
+++ b/tests/titleScreen.test.js
@@ -5,9 +5,9 @@ jest.mock('phaser', () => ({
 
 jest.mock('../src/firebase.js', () => ({
   __esModule: true,
-  db: {},
+  db: { collection: jest.fn(() => ({ doc: jest.fn(() => ({ set: jest.fn() })) })) },
   firebase: {},
-  auth: { onAuthStateChanged: jest.fn() },
+  auth: { onAuthStateChanged: jest.fn(), currentUser: null },
   googleProvider: {}
 }));
 


### PR DESCRIPTION
## Summary
- track additional user stats when the player dies
- import `auth` in Game scene
- update Firebase mocks in unit tests for new Firestore calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688564fddf50832c8f633d3f0169b823