### PR TITLE
Implement gold reward system

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -56,6 +56,7 @@ class Game extends Phaser.Scene {
         // Initialize per-session counters
         this.sessionStart = Date.now();
         this.enemiesKilledSess = 0;
+        HUD_TEXTS.gold = 0;
     }
 
     create() {
@@ -156,6 +157,9 @@ class Game extends Phaser.Scene {
 
         if (player.health <= 0) {
             this.isGameOver = true;
+
+            // ensure gold reflects total enemies killed this session
+            HUD_TEXTS.gold = Math.floor(this.enemiesKilledSess / 10);
 
             const nickname = localStorage.getItem('nickname') || 'Anônimo';
             const survivalTime = Math.floor((Date.now() - this.startTime) / 1000);

--- a/src/scenes/helpers/projectiles.js
+++ b/src/scenes/helpers/projectiles.js
@@ -1,3 +1,5 @@
+import { HUD_TEXTS } from "../HUDConstants";
+
 export function fireProjectile(scene) {
     if (
         scene.enemies.getChildren().length === 0 &&
@@ -72,6 +74,13 @@ export function updateProjectiles(scene) {
             scene.shooters.remove(projectile.target, true, true);
             if (typeof scene.enemiesKilledSess === 'number') {
                 scene.enemiesKilledSess += 1;
+                if (scene.hudTexts && scene.hudTexts.gold) {
+                    const newGold = Math.floor(scene.enemiesKilledSess / 10);
+                    if (newGold > HUD_TEXTS.gold) {
+                        HUD_TEXTS.gold = newGold;
+                        scene.hudTexts.gold.setText(`Gold: ${HUD_TEXTS.gold}`);
+                    }
+                }
             }
             projectile.destroy();
         }

--- a/tests/goldIncrement.test.js
+++ b/tests/goldIncrement.test.js
@@ -1,0 +1,46 @@
+jest.mock('phaser', () => ({
+  __esModule: true,
+  default: {
+    Scene: class Scene {},
+    Math: {
+      Angle: { Between: jest.fn(() => 0) },
+      Distance: {
+        Squared: jest.fn(() => 0)
+      }
+    }
+  }
+}));
+
+import { updateProjectiles } from '../src/scenes/helpers/projectiles.js';
+import { HUD_TEXTS } from '../src/scenes/HUDConstants.js';
+import Phaser from 'phaser';
+
+global.Phaser = Phaser;
+
+test('increments gold every 10 kills', () => {
+  const goldText = { setText: jest.fn() };
+  const target = { shootEvent: {}, destroy: jest.fn(), active: true, x: 0, y: 0 };
+  const projectile = {
+    active: true,
+    target,
+    x: 0,
+    y: 0,
+    body: { setVelocity: jest.fn() },
+    destroy: jest.fn()
+  };
+  const scene = {
+    projectiles: { children: { each: (fn, ctx) => fn.call(ctx, projectile) } },
+    enemies: { remove: jest.fn(), getChildren: jest.fn(() => []) },
+    shooters: { remove: jest.fn(), getChildren: jest.fn(() => []) },
+    enemiesKilledSess: 9,
+    hudTexts: { gold: goldText },
+    projectileSpeed: 100,
+    time: { removeEvent: jest.fn() },
+    game: { config: { width: 800, height: 600 } }
+  };
+  HUD_TEXTS.gold = 0;
+  updateProjectiles(scene);
+  expect(scene.enemiesKilledSess).toBe(10);
+  expect(HUD_TEXTS.gold).toBe(1);
+  expect(goldText.setText).toHaveBeenCalledWith('Gold: 1');
+});


### PR DESCRIPTION
## Summary
- reset gold each game session
- count kills and update gold in real-time
- send earned gold to Firebase on death
- test gold increment logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885873592f4832c841312e70e312ef7