### PR TITLE
fix round spawn after clearing wave

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -147,7 +147,7 @@ class Game extends Phaser.Scene {
         enforcePlayerBounds(this);
 
         // Atualiza valores do HUD
-        const alive = this.enemies.getChildren().length + this.shooters.getChildren().length;
+        const alive = this.enemies.countActive(true) + this.shooters.countActive(true);
         if (alive === 0 && !this.nextWaveScheduled) {
             this.nextWaveScheduled = true;
             this.time.delayedCall(1000, () => {


### PR DESCRIPTION
## Summary
- ensure wave progression counts only active enemies

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68872801a04c832c9e4ecd93b71cec5c