### PR TITLE
Fix viewport to disable pinch zoom

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" />
   <title>Bullet Rush</title>
 
   <!-- Ícone da aba do navegador -->


### PR DESCRIPTION
## Summary
- prevent mobile pinch zoom by adding `maximum-scale=1, user-scalable=no`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68876453cc20832c884c3c35b6c496cd