### PR TITLE
Implement camera resizing handlers

### DIFF
--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -73,6 +73,18 @@ class Game extends Phaser.Scene {
     }
 
     create() {
+        // Ajusta a viewport da câmera em redimensionamentos
+        this.scale.on('resize', (size) => {
+            this.cameras.main.setViewport(0, 0, size.width, size.height);
+        });
+
+        // Limites iniciais da câmera caso o mapa ultrapasse a tela
+        this.cameras.main.setBounds(
+            0,
+            0,
+            this.game.config.width,
+            this.game.config.height
+        );
         this.cursors = this.input.keyboard.createCursorKeys();
         this.wasdKeys = this.input.keyboard.addKeys('W,A,S,D');
 

--- a/src/scenes/TitleScreen.js
+++ b/src/scenes/TitleScreen.js
@@ -40,6 +40,11 @@ export default class TitleScreen extends Phaser.Scene {
 
     async create() {
 
+        // Ajusta a viewport da câmera em redimensionamentos
+        this.scale.on('resize', (size) => {
+            this.cameras.main.setViewport(0, 0, size.width, size.height);
+        });
+
         this.playerGold = 0;
         this.skinImg = null;
 

--- a/tests/externalInput.test.js
+++ b/tests/externalInput.test.js
@@ -32,6 +32,7 @@ test('uses external nickname input if available', async () => {
 
   const scene = new TitleScreen();
   scene.cameras = { main: { centerX: 0, centerY: 0 } };
+  scene.scale = { on: jest.fn() };
   scene.add = {
     text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),
     dom: jest.fn()

--- a/tests/nicknameInput.test.js
+++ b/tests/nicknameInput.test.js
@@ -25,6 +25,7 @@ import TitleScreen from '../src/scenes/TitleScreen.js';
 test('nickname input focuses on click', async () => {
   const scene = new TitleScreen();
   scene.cameras = { main: { centerX: 0, centerY: 0 } };
+  scene.scale = { on: jest.fn() };
 
   const input = document.createElement('input');
   const addEventListenerSpy = jest.spyOn(input, 'addEventListener');

--- a/tests/noScoresMessage.test.js
+++ b/tests/noScoresMessage.test.js
@@ -24,6 +24,7 @@ import TitleScreen from '../src/scenes/TitleScreen.js';
 test('shows message when no scores', async () => {
   const scene = new TitleScreen();
   scene.cameras = { main: { centerX: 0, centerY: 0 } };
+  scene.scale = { on: jest.fn() };
   const input = document.createElement('input');
   scene.add = {
     text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),

--- a/tests/rankingDisplay.test.js
+++ b/tests/rankingDisplay.test.js
@@ -31,6 +31,7 @@ import TitleScreen from '../src/scenes/TitleScreen.js';
 test('displays ranking from firebase', async () => {
   const scene = new TitleScreen();
   scene.cameras = { main: { centerX: 0, centerY: 0 } };
+  scene.scale = { on: jest.fn() };
   const input = document.createElement('input');
   scene.add = {
     text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),

--- a/tests/titleScreen.test.js
+++ b/tests/titleScreen.test.js
@@ -49,6 +49,7 @@ test('TitleScreen extends Phaser.Scene', () => {
 test('saves user info on login', async () => {
   const scene = new TitleScreen();
   scene.cameras = { main: { centerX: 0, centerY: 0 } };
+  scene.scale = { on: jest.fn() };
   const input = document.createElement('input');
   scene.add = {
     text: jest.fn(() => ({ setOrigin: jest.fn().mockReturnThis(), setInteractive: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),


### PR DESCRIPTION
## Summary
- adjust camera viewport on window resize in game and title scenes
- set initial camera bounds when scenes are created
- update unit tests with mock `scale` object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887676ba2a8832ca33045918f1bfe07